### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/pajtai/grunt-requirejs-paths/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/pajtai/grunt-requirejs-paths/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "Gruntfile.js",
   "engines": {
     "node": ">= 0.8.19"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license